### PR TITLE
Thresholds for completeness plot

### DIFF
--- a/multiqc_bcbio/bcbio.py
+++ b/multiqc_bcbio/bcbio.py
@@ -285,7 +285,7 @@ class MultiqcModule(BaseMultiqcModule):
                 bcbio_data.append(data_obj)
                 cutoffs.append(int(pct_key.split("percentage")[1]))
 
-        if bcbio_data[0] and cutoffs:
+        if bcbio_data and bcbio_data[0] and cutoffs:
             return linegraph(self, bcbio_data, {
                 'data_labels': [
                     {'name': str(c) + 'x'} for c in cutoffs
@@ -501,7 +501,8 @@ def add_project_info(data):
         else:
             if coverage_bed_info:
                 config.report_header_info.append({"Target for coverage:": _format_bed_info(coverage_bed_info, genome_info)})
-            config.report_header_info.append({"Target for var. calling:": _format_bed_info(variants_regions_info, genome_info)})
+            if variants_regions_info and variants_regions_info['bed']:
+                config.report_header_info.append({"Target for var. calling:": _format_bed_info(variants_regions_info, genome_info)})
 
 
 def _format_bed_info(d, genome_info):

--- a/multiqc_bcbio/bcbio.py
+++ b/multiqc_bcbio/bcbio.py
@@ -243,7 +243,9 @@ class MultiqcModule(BaseMultiqcModule):
         if any(['rRNA_rate' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['rRNA_rate'] = {
                 'title': 'rRNA pct',
-                'description': '% alignments to rRNA',
+                'description': '% alignments to rRNA. Depending on the library preparation methods used, the proportion '
+                               'of rRNA sequences should be quite low. If large proportions of rRNA sequences are seen, '
+                               'it is wise to consider if the depth of the remaining sequences is sufficient for further analyses.',
                 'max': 100,
                 'min': 0,
                 'modify': lambda x: x * 100,
@@ -474,6 +476,10 @@ def _get_disambiguited(dt):
             if k.startswith("Disambiguated"):
                 h[k] = {
                     'title': k.replace("_", " ").replace("Disambiguated", "Disamb."),
+                    'description': 'When samples are at risk of cross-species contamination (e.g. those '
+                                   'derived from PDXs), an attempt is performed to remove reads that are '
+                                   'assigned to the different species involved. This metric shows the number '
+                                   'of removed reads.',
                     'min': 0,
                     'format': '{:.0f}',
                     'shared_key': 'read_count',

--- a/multiqc_bcbio/bcbio.py
+++ b/multiqc_bcbio/bcbio.py
@@ -165,7 +165,7 @@ class MultiqcModule(BaseMultiqcModule):
             }
         if any(['Mapped_reads_pct' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Mapped_reads_pct'] = {
-                'title': '% Mapped',
+                'title': '% Aln',
                 'description': '% Mapped reads',
                 'min': 0, 'max': 100, 'suffix': '%',
                 'scale': 'RdYlGn',
@@ -173,7 +173,7 @@ class MultiqcModule(BaseMultiqcModule):
             }
         if any(['Duplicates_pct' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Duplicates_pct'] = {
-                'title': '% Dups',
+                'title': '% Dup',
                 'description': '% Duplicated mapped reads',
                 'min': 0, 'max': 100, 'suffix': '%',
                 'scale': 'RdYlGn',
@@ -181,7 +181,7 @@ class MultiqcModule(BaseMultiqcModule):
             }
         if any(['Ontarget_pct' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Ontarget_pct'] = {
-                'title': '% On-targets',
+                'title': '% On-trg',
                 'description': '% On-target mapped not-duplicate reads',
                 'min': 0, 'max': 100, 'suffix': '%',
                 'scale': 'RdYlGn',
@@ -189,7 +189,7 @@ class MultiqcModule(BaseMultiqcModule):
             }
         if any(['Ontarget_padded_pct' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Ontarget_padded_pct'] = {
-                'title': '% On-targets+200bp',
+                'title': '% On-trg+200bp',
                 'description': '% Reads that overlap target regions extended by 200 bp. Expected to be 1-2% higher.',
                 'min': 0, 'max': 100, 'suffix': '%',
                 'scale': 'RdYlGn',
@@ -206,7 +206,7 @@ class MultiqcModule(BaseMultiqcModule):
             }
         if any(['Avg_coverage' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Avg_coverage'] = {
-                'title': 'Avg. Depth',
+                'title': 'Depth',
                 'description': 'Average target read coverage',
                 'format': '{:.2f}',
             }
@@ -242,7 +242,7 @@ class MultiqcModule(BaseMultiqcModule):
             }
         if any(['rRNA_rate' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['rRNA_rate'] = {
-                'title': 'rRNA rate',
+                'title': 'rRNA pct',
                 'description': '% alignments to rRNA',
                 'max': 100,
                 'min': 0,


### PR DESCRIPTION
Following this RP in bcbio-nextgen: https://github.com/chapmanb/bcbio-nextgen/pull/1707
Instead of hard-coding coverage cutoffs, read them from the raw file header.

And few other updates:
- Move genome/target info into the header, and make the method static;
- Add descriptions to rRNA pct and disambiguated reads metrics;
- Rename rRNA rate -> rRNA pct for consistency across other metrics (rate is below 1, pct is below 100);
- A little bit shorter column names in general stats (it may become overcrowded).