### PR TITLE
Clip long tail in coverage profile plot, and update read stats descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.pyc
+.idea/
+.DS_Store
+*.egg-info/
+build/
+dist/
+

--- a/multiqc_bcbio/bcbio.py
+++ b/multiqc_bcbio/bcbio.py
@@ -147,7 +147,7 @@ class MultiqcModule(BaseMultiqcModule):
         if any(['Total_reads' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Total_reads'] = {
                 'title': 'Reads',
-                'description': 'Total sequences in the bam file',
+                'description': 'Total sequences in the bam file (exluding secondary alignments)',
                 'min': 0,
                 'modify': lambda x: x / 1000000,
                 'shared_key': 'read_count',
@@ -156,7 +156,7 @@ class MultiqcModule(BaseMultiqcModule):
         if any(['Mapped_reads' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Mapped_reads'] = {
                 'title': 'Mapped',
-                'description': 'Mapped reads number',
+                'description': 'Mapped (both mates, primary) reads number',
                 'min': 0,
                 'modify': lambda x: x / 1000000,
                 'shared_key': 'read_count',
@@ -166,7 +166,7 @@ class MultiqcModule(BaseMultiqcModule):
         if any(['Mapped_reads_pct' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Mapped_reads_pct'] = {
                 'title': '% Aln',
-                'description': '% Mapped reads',
+                'description': '% Mapped reads (both mates, primary)',
                 'min': 0, 'max': 100, 'suffix': '%',
                 'scale': 'RdYlGn',
                 'format': '{:.1f}%',
@@ -174,7 +174,7 @@ class MultiqcModule(BaseMultiqcModule):
         if any(['Duplicates_pct' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Duplicates_pct'] = {
                 'title': '% Dup',
-                'description': '% Duplicated mapped reads',
+                'description': '% Duplicated reads',
                 'min': 0, 'max': 100, 'suffix': '%',
                 'scale': 'RdYlGn',
                 'format': '{:.1f}%'
@@ -182,7 +182,7 @@ class MultiqcModule(BaseMultiqcModule):
         if any(['Ontarget_pct' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Ontarget_pct'] = {
                 'title': '% On-trg',
-                'description': '% On-target mapped not-duplicate reads',
+                'description': '% On-target (both mates, primary) mapped not-duplicate reads',
                 'min': 0, 'max': 100, 'suffix': '%',
                 'scale': 'RdYlGn',
                 'format': '{:.1f}%'


### PR DESCRIPTION
Updated columns descriptions to addressed that we slightly changed the way we calculate read stats (pull them from `samtools stats` which skips secondary alignments and also require both mates mapped for mapped statistics - https://github.com/chapmanb/bcbio-nextgen/pull/1711) 

Also following the slack discussion about the coverage profile plot, added a feature to clip the high-coverage long tail the same way it's done in QualiMap.