### PR TITLE
Aggregating MultiQC_bcbio configuration in one place

### DIFF
--- a/multiqc_bcbio/__init__.py
+++ b/multiqc_bcbio/__init__.py
@@ -37,5 +37,22 @@ def multiqc_bcbio_config():
             'reads_mapped': False,
             'reads_mapped_percent': False,
             'raw_total_sequences': False,
-        }
+            'error_rate': False,
+        },
+        'SnpEff': {
+            'Change_rate': False,
+            'Ts_Tv_ratio': False,
+            'Number_of_variants_before_filter': False,
+        },
     })
+    config.module_order = [
+        "bcbio",
+        "samtools",
+        "goleft_indexcov",
+        "bcftools",
+        "picard",
+        "qualimap",
+        "snpeff",
+        "fastqc",
+        "preseq"
+    ]

--- a/multiqc_bcbio/bcbio.py
+++ b/multiqc_bcbio/bcbio.py
@@ -157,7 +157,7 @@ class MultiqcModule(BaseMultiqcModule):
             headers['Total_reads'] = {
                 'title': 'Reads',
                 'description': 'Total raw sequences' +
-                               (' ({})' + str(config.read_count_desc) if config.read_count_desc else ''),
+                               (' ({})'.format(config.read_count_desc) if config.read_count_desc else ''),
                 'min': 0,
                 'modify': lambda x: x * config.read_count_multiplier,
                 'shared_key': 'read_count',
@@ -167,7 +167,7 @@ class MultiqcModule(BaseMultiqcModule):
             headers['Mapped_reads'] = {
                 'title': 'Aln',
                 'description': 'Total number of read alignments' +
-                               (' ({})' + str(config.read_count_desc) if config.read_count_desc else ''),
+                               (' ({})'.format(config.read_count_desc) if config.read_count_desc else ''),
                 'min': 0,
                 'modify': lambda x: x * config.read_count_multiplier,
                 'shared_key': 'read_count',


### PR DESCRIPTION
1. Moving `table_columns_visible` and `module_order` settings from bcbio source: https://github.com/chapmanb/bcbio-nextgen/blob/master/bcbio/qc/multiqc.py#L184

2. Additionally, a minor fix in metrics descriptions.