### PR TITLE
Coverage plotting mosdepth migration and minor changes

### DIFF
--- a/multiqc_bcbio/__init__.py
+++ b/multiqc_bcbio/__init__.py
@@ -51,14 +51,3 @@ def multiqc_bcbio_config():
             'Number_of_variants_before_filter': False,
         },
     })
-    config.module_order = [
-        "bcbio",
-        "samtools",
-        "goleft_indexcov",
-        "bcftools",
-        "picard",
-        "qualimap",
-        "snpeff",
-        "fastqc",
-        "preseq"
-    ]

--- a/multiqc_bcbio/__init__.py
+++ b/multiqc_bcbio/__init__.py
@@ -31,6 +31,7 @@ def multiqc_bcbio_config():
         },
         'QualiMap': {
             'percentage_aligned': False,
+            'median_coverage': False,
         },
         'Samtools Stats': {
             'non-primary_alignments': False,

--- a/multiqc_bcbio/__init__.py
+++ b/multiqc_bcbio/__init__.py
@@ -9,8 +9,8 @@ def multiqc_bcbio_config():
     """ Set up MultiQC config defaults for this package """
     bcbio_search_patterns = {
         'bcbio/metrics': {'fn': '*_bcbio.txt'},
-        'bcbio/coverage': {'fn': '*_bcbio_coverage.txt'},
-        'bcbio/coverage_avg': {'fn': '*_bcbio_coverage_avg.txt'},
+        'bcbio/coverage_dist': {'fn': '*-coverage.mosdepth.dist.txt'},
+        'bcbio/coverage_avg': {'fn': '*_bcbio_coverage_avg.txt'},  # deprecated in 1.0.6, replaced with 'bcbio/coverage_dist'
         'bcbio/variants': {'fn': '*_bcbio_variants.txt'},
         'bcbio/target': {'fn': 'target_info.yaml'},
         'bcbio/qsignature': {'fn': '*bcbio_qsignature.ma'},
@@ -22,7 +22,12 @@ def multiqc_bcbio_config():
     }
     config.update_dict(config.sp, bcbio_search_patterns)
 
-    config.fn_clean_exts.append({'type': 'regex', 'pattern': '_bcbio.*'})
+    config.fn_clean_exts.extend([
+        {'type': 'regex', 'pattern': '_bcbio.*'},
+    ])
+    config.fn_clean_trim.extend([
+        '-coverage.mosdepth.dist',
+    ])
     
     config.update_dict(config.table_columns_visible, {
         'FastQC': {

--- a/multiqc_bcbio/bcbio.py
+++ b/multiqc_bcbio/bcbio.py
@@ -316,7 +316,7 @@ class MultiqcModule(BaseMultiqcModule):
         x_threshold = 0
         data = defaultdict(dict)
         for f in self.find_log_files(names):
-            s_name = self.clean_s_name(f['fn'].replace(), root=None)
+            s_name = self.clean_s_name(f['fn'], root=None)
             for line in f['f'].split("\n"):
                 if not line.startswith("percentage"):
                     continue

--- a/multiqc_bcbio/bcbio.py
+++ b/multiqc_bcbio/bcbio.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 """ MultiQC module to parse output from bcbio"""
 

--- a/multiqc_bcbio/bcbio.py
+++ b/multiqc_bcbio/bcbio.py
@@ -157,8 +157,7 @@ class MultiqcModule(BaseMultiqcModule):
         if any(['Total_reads' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Total_reads'] = {
                 'title': 'Reads',
-                'description': 'Total raw sequences' +
-                               (' ({})'.format(config.read_count_desc) if config.read_count_desc else ''),
+                'description': 'Total read count in the output BAM file (including unmapped, etc.)',
                 'min': 0,
                 'modify': lambda x: x * config.read_count_multiplier,
                 'shared_key': 'read_count',
@@ -167,8 +166,7 @@ class MultiqcModule(BaseMultiqcModule):
         if any(['Mapped_reads' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Mapped_reads'] = {
                 'title': 'Aln',
-                'description': 'Total number of read alignments' +
-                               (' ({})'.format(config.read_count_desc) if config.read_count_desc else ''),
+                'description': 'Total number of read alignments',
                 'min': 0,
                 'modify': lambda x: x * config.read_count_multiplier,
                 'shared_key': 'read_count',
@@ -226,9 +224,8 @@ class MultiqcModule(BaseMultiqcModule):
             }
         if any(['Average_insert_size' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Average_insert_size'] = {
-                'title': 'Insert Size',
-                'description': 'Average insert size',
-                'suffix': 'bp',
+                'title': 'Mean IS',
+                'description': 'Mean insert size (samtools stats)',
                 'format': '{:.0f}',
             }
         if any(['Disambiguated_ambiguous_reads' in self.bcbio_data[s] for s in self.bcbio_data]):
@@ -351,21 +348,21 @@ class MultiqcModule(BaseMultiqcModule):
                                      'description': 'Percent of original reads removed by consensus',
                                      'suffix': '%',
                                      'format': '{:,.1f}'}
-        keys['umi_baseline_mapped'] = {'title': "Original mapped",
+        keys['umi_baseline_all'] = {'title': 'Orig. total',
+                                    'description': 'Total reads in the original BAM',
+                                    'format': '{:n}'}
+        keys['umi_baseline_mapped'] = {'title': "Orig. mapped",
                                        'description': 'Count of original mapped reads',
                                        'format': '{:n}'}
-        keys['umi_baseline_duplicate_pct'] = {'title': 'Original duplicates',
+        keys['umi_baseline_duplicate_pct'] = {'title': 'Orig. dup',
                                               'description': 'Percentage original duplicates',
                                               'suffix': '%',
                                               'format': '{:,.1f}'}
-        keys['umi_baseline_all'] = {'title': 'Original total',
-                                    'description': 'Total reads in the original BAM',
-                                    'format': '{:n}'}
-        keys['umi_reduction_median'] = {'title': 'Duplicate reduction (median)',
+        keys['umi_reduction_median'] = {'title': 'Dup. reduction (median)',
                                         'description': 'Reduction in duplicates per position by UMIs (median)',
                                         'suffix': 'x',
                                         'format': '{:n}'}
-        keys['umi_reduction_max'] = {'title': 'Duplicate reduction (max)',
+        keys['umi_reduction_max'] = {'title': 'Dup. reduction (max)',
                                      'description': 'Reduction in duplicates per position by UMIs (maximum)',
                                      'suffix': 'x',
                                      'format': '{:n}'}

--- a/multiqc_bcbio/bcbio.py
+++ b/multiqc_bcbio/bcbio.py
@@ -234,12 +234,11 @@ class MultiqcModule(BaseMultiqcModule):
 
         if any(['rRNA_rate' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['rRNA_rate'] = {
-                'title': 'rRNA pct',
+                'title': 'rRNA',
                 'description': '% alignments to rRNA. Depending on the library preparation methods used, the proportion '
                                'of rRNA sequences should be quite low. If large proportions of rRNA sequences are seen, '
                                'it is wise to consider if the depth of the remaining sequences is sufficient for further analyses.',
-                'max': 100,
-                'min': 0,
+                'min': 0, 'max': 100, 'suffix': '%',
                 'modify': lambda x: x * 100,
                 'scale': 'RdYlGn',
                 'format': '{:,.1f}'

--- a/multiqc_bcbio/bcbio.py
+++ b/multiqc_bcbio/bcbio.py
@@ -148,8 +148,8 @@ class MultiqcModule(BaseMultiqcModule):
             log.error("Cannot import MultiQC_bcbio sRNA.")
         else:
             headers.update(srna.add_srna_headers(self.bcbio_data))
-        
-        read_format = '{:,.2f} ' + config.read_count_prefix
+
+        read_format = '{:,.1f}&nbsp;' + config.read_count_prefix
         if config.read_count_multiplier == 1:
             read_format = '{:,.0f}'
             
@@ -176,7 +176,7 @@ class MultiqcModule(BaseMultiqcModule):
             }
         if any(['Mapped_reads_pct' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Mapped_reads_pct'] = {
-                'title': '% Map',
+                'title': 'Aln',
                 'description': '% Mapped reads',
                 'min': 0,
                 'max': 100,
@@ -186,7 +186,7 @@ class MultiqcModule(BaseMultiqcModule):
             }
         if any(['Duplicates_pct' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Duplicates_pct'] = {
-                'title': '% Dup',
+                'title': 'Dup',
                 'description': '% Duplicated reads',
                 'min': 0, 'max': 100, 'suffix': '%',
                 'scale': 'RdYlGn',
@@ -194,7 +194,7 @@ class MultiqcModule(BaseMultiqcModule):
             }
         if any(['Ontarget_pct' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Ontarget_pct'] = {
-                'title': '% On-trg',
+                'title': 'On-trg',
                 'description': '% On-target (both mates, primary) mapped not-duplicate reads',
                 'min': 0, 'max': 100, 'suffix': '%',
                 'scale': 'RdYlGn',
@@ -202,7 +202,7 @@ class MultiqcModule(BaseMultiqcModule):
             }
         if any(['Ontarget_padded_pct' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Ontarget_padded_pct'] = {
-                'title': '% On-trg+200bp',
+                'title': '±200bp',
                 'description': '% Reads that overlap target regions extended by 200 bp. Expected to be 1-2% higher.',
                 'min': 0, 'max': 100, 'suffix': '%',
                 'scale': 'RdYlGn',
@@ -211,7 +211,7 @@ class MultiqcModule(BaseMultiqcModule):
             }
         if any(['Usable_pct' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Usable_pct'] = {
-                'title': '% Usable',
+                'title': 'Usable',
                 'description': '% Unique reads mapped on target in the total number of original reads.',
                 'min': 0, 'max': 100, 'suffix': '%',
                 'scale': 'RdYlGn',
@@ -219,9 +219,9 @@ class MultiqcModule(BaseMultiqcModule):
             }
         if any(['Avg_coverage' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Avg_coverage'] = {
-                'title': 'Depth',
+                'title': 'Cov',
                 'description': 'Average target read coverage',
-                'format': '{:,.2f}',
+                'format': '{:,.1f}',
             }
         if any(['Average_insert_size' in self.bcbio_data[s] for s in self.bcbio_data]):
             headers['Average_insert_size'] = {

--- a/multiqc_bcbio/bcbio.py
+++ b/multiqc_bcbio/bcbio.py
@@ -478,8 +478,9 @@ def _get_disambiguited(dt):
                                    'assigned to the different species involved. This metric shows the number '
                                    'of removed reads.',
                     'min': 0,
-                    'format': '{:.0f}',
+                    'modify': lambda x: x * config.read_count_multiplier,
                     'shared_key': 'read_count',
+                    'format': read_format,
                     'scale': 'RdYlGn',
                 }
     return h

--- a/multiqc_bcbio/bcbio.py
+++ b/multiqc_bcbio/bcbio.py
@@ -472,8 +472,8 @@ def _get_disambiguited(dt):
         for k in dt[s]:
             if k.startswith("Disambiguated"):
                 h[k] = {
-                    'title': k.replace("_", " ").replace("Disambiguated", "Disamb."),
-                    'description': 'When samples are at risk of cross-species contamination (e.g. those '
+                    'title': k.replace("Disambiguated_", "").replace("_reads", "").replace("ambiguous", "Ambig.").replace("_", " "),
+                    'description': 'Disambuguation. When samples are at risk of cross-species contamination (e.g. those '
                                    'derived from PDXs), an attempt is performed to remove reads that are '
                                    'assigned to the different species involved. This metric shows the number '
                                    'of removed reads.',

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,12 @@ For more information about MultiQC, see http://multiqc.info
 
 from setuptools import setup, find_packages
 
-version = '0.2.2'
+version = '0.2.3'
 
 setup(
     name = 'multiqc_bcbio',
     version = version,
-    author = 'Lorena Pantano, Brad Chapman , Vlad Saveliev, Phil Ewels',
+    author = 'Lorena Pantano, Brad Chapman, Vlad Saveliev, Phil Ewels',
     author_email = 'lpantano@iscb.org',
     description = "MultiQC plugin for bcbio_nextgen pipeline",
     long_description = __doc__,


### PR DESCRIPTION
After migrating to mosdepth, coverage QC files format and naming changed. Addressing it here:
- use new mosdepth's output instead of old-style files for coverage dist plot, and support old-style as deprecated;
- remove coverage completeness plot (we don't generate data for that in bcbio, can think how to put it back if this plot will be needed in the future).

Other than that, multiple minor fixes:
- applying `read_count_multiplier` and `base_count_multiplier` wherever makes sense
- set y_max=100 for percentages,
- more compact column names,
- added M and % suffixes for consistency,
- hide qualimap's median coverage which is reported by bcbio itself,
- fix descriptions formatting.