### PR TITLE
Viral stats: use completeness (% at 5x) instead of read count

### DIFF
--- a/multiqc_bcbio/__init__.py
+++ b/multiqc_bcbio/__init__.py
@@ -17,7 +17,8 @@ def multiqc_bcbio_config():
         'bcbio/vcfstats': {'fn': '*_bcbio_variants_stats.txt'},
         'bcbio/seqbuster': {'contents': 'seqbuster'},
         'bcbio/umi': {'fn': '*_umi_stats.yaml'},
-        'bcbio/viral': {'fn': '*viral*-counts.txt'},
+        'bcbio/viral_old': {'fn': '*viral*-counts.txt'},
+        'bcbio/viral': {'fn': '*viral*-completeness.txt'},
         'bcbio/damage': {'fn': '*damage.yaml'},
     }
     config.update_dict(config.sp, bcbio_search_patterns)


### PR DESCRIPTION
In viral stats table, we report the number of reads supporting each viral sequence. This metric doesn't take into account the size of the virus; And also, in some tests I ran into viruses that contained a small repeat that attracted thousands of reads, resulting in one colossal coverage peak, with 0 coverage all along the rest of the viral sequence.

To account for those issues, I suggest to calculate coverage completeness - e.g. % viral sequence covered at 5x - and rate the viruses based on this metric instead of read count.

The updated report will look like this:
 
![screen shot 2018-04-27 at 16 03 10](https://user-images.githubusercontent.com/1575412/39347098-a207878e-4a34-11e8-9522-500faa4f35dc.png)

Complementing this bcbio PR: https://github.com/bcbio/bcbio-nextgen/pull/2381