### PR TITLE
Viral stats: do not show empty section if viral was not run at all

### DIFF
--- a/multiqc_bcbio/bcbio.py
+++ b/multiqc_bcbio/bcbio.py
@@ -508,13 +508,14 @@ class MultiqcModule(BaseMultiqcModule):
             "title": "Viral content",
             "description": 'Virus (x depth; % of sequence covered at >{}).'.format(completeness_threshold),
         }
-        return {"name": "Viral content",
-                "anchor": "viral-content",
-                "description": (
-                    'Viral sequences from <a href="https://gdc.cancer.gov/about-data/data-harmonization-and-generation/gdc-reference-files">GDC</a> found in unmapped reads. '
-                    'Showing significant hits with at least {} support along at least {}% of the genome.'
-                    ).format(completeness_threshold, int(100 * min_significant_completeness)),
-                "plot": table.plot(data, keys)}
+        if data:
+            return {"name": "Viral content",
+                    "anchor": "viral-content",
+                    "description": (
+                        'Viral sequences from <a href="https://gdc.cancer.gov/about-data/data-harmonization-and-generation/gdc-reference-files">GDC</a> found in unmapped reads. '
+                        'Showing significant hits with at least {} support along at least {}% of the genome.'
+                        ).format(completeness_threshold, int(100 * min_significant_completeness)),
+                    "plot": table.plot(data, keys)}
 
     def get_damage_stats(self, fnames):
         """Summarize statistics on samples with DNA damage.


### PR DESCRIPTION
Since bcbio counts the viral content only in paired data:
https://github.com/bcbio/bcbio-nextgen/blob/master/bcbio/pipeline/qcsummary.py#L110-L111
For unpaired data MultiQC will end up with an empty section.

Changing it to show the section only if any viral files were found.

By the way, any reason not to run it for unpaired data? Maybe for tumor-only runs it still makes sense?