### PR TITLE
Hotfix to avoid circular import issue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,6 @@ install:
   - cd test_data
 # commands to run tests
 script:
+  - python -c 'import multiqc_bcbio.bcbio'
   - multiqc data/bcbio/*
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.8"
 # commands to install dependencies
 before_install:
   - git clone https://github.com/ewels/MultiQC.git

--- a/multiqc_bcbio/__init__.py
+++ b/multiqc_bcbio/__init__.py
@@ -1,11 +1,8 @@
 from __future__ import absolute_import
 
-from .bcbio import MultiqcModule
-from multiqc import config
-
-
 # Add search patterns and config options for the things that are used in MultiQC_bcbio
 def multiqc_bcbio_config():
+    from multiqc import config
     """ Set up MultiQC config defaults for this package """
     bcbio_search_patterns = {
         'bcbio/metrics': {'fn': '*_bcbio.txt'},

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,12 @@ For more information about MultiQC, see http://multiqc.info
 
 from setuptools import setup, find_packages
 
-version = '0.2.7'
+version = '0.2.8'
 
 setup(
     name = 'multiqc_bcbio',
     version = version,
-    author = 'Lorena Pantano, Brad Chapman, Vlad Saveliev, Phil Ewels',
+    author = 'Lorena Pantano, Brad Chapman, Vlad Saveliev, Phil Ewels, Rory Kirchner',
     author_email = 'lpantano@iscb.org',
     description = "MultiQC plugin for bcbio_nextgen pipeline",
     long_description = __doc__,


### PR DESCRIPTION
With python3.8 we get circular import errors. I couldn't figure out how
or why this was happening specifically with python 3.8, but if we
protect the import by moving it inside of the function then we avoid it.

https://bugs.python.org/issue33237 is the error message change, but it's
unclear to me why it is triggering in 3.8 but not 3.7.